### PR TITLE
Add StreamingPreflight gate for queueStreamRelayJob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log
 
 # Local deploy SSH keys (never commit)
 /.deploy/
+/composer

--- a/app/Http/Controllers/Organization/LivestreamController.php
+++ b/app/Http/Controllers/Organization/LivestreamController.php
@@ -9,6 +9,7 @@ use App\Models\Organization;
 use App\Models\OrganizationLivestream;
 use App\Models\StreamingJob;
 use App\Models\UserLivestream;
+use App\Services\Streaming\StreamingPreflight;
 use App\Services\Streaming\StreamingQueueService;
 use App\Support\MeetingRecordingPreference;
 use App\Support\StreamingWorkerSourceUrl;
@@ -688,7 +689,7 @@ class LivestreamController extends Controller
      * Enqueue AWS streaming worker (SQS): pull meeting video from the host VDO URL and push RTMP to YouTube.
      * Legacy route "go-live-obs-auto" is an alias — this does not use OBS.
      */
-    public function queueStreamRelayJob(Request $request, $id, StreamingQueueService $streamingQueue)
+    public function queueStreamRelayJob(Request $request, $id, StreamingQueueService $streamingQueue, StreamingPreflight $preflight)
     {
         $user = Auth::user();
         $organization = $user->organization ?? Organization::where('user_id', $user->id)->first();
@@ -704,6 +705,11 @@ class LivestreamController extends Controller
             return redirect()->back()->withErrors([
                 'go_live' => 'Cannot queue the cloud stream in this state (status: '.$livestream->status.'). End any active stream first, or reset the meeting.',
             ]);
+        }
+
+        $gate = $preflight->check($livestream, $user);
+        if (! $gate->allowed) {
+            return redirect()->back()->withErrors(['go_live' => $gate->reason]);
         }
 
         $streamKey = $livestream->getDecryptedStreamKey();

--- a/app/Http/Controllers/SupporterLivestreamController.php
+++ b/app/Http/Controllers/SupporterLivestreamController.php
@@ -8,6 +8,7 @@ use App\Models\OrganizationLivestream;
 use App\Models\StreamingJob;
 use App\Models\User;
 use App\Models\UserLivestream;
+use App\Services\Streaming\StreamingPreflight;
 use App\Services\Streaming\StreamingQueueService;
 use App\Support\MeetingRecordingPreference;
 use App\Support\StreamingWorkerSourceUrl;
@@ -831,7 +832,7 @@ class SupporterLivestreamController extends Controller
      * Enqueue AWS streaming worker (SQS): pull meeting video from the host VDO URL and push RTMP to YouTube.
      * Legacy route name "go-live-obs-auto" is kept as an alias — this path does not use OBS.
      */
-    public function queueStreamRelayJob(Request $request, int $id, StreamingQueueService $streamingQueue): RedirectResponse
+    public function queueStreamRelayJob(Request $request, int $id, StreamingQueueService $streamingQueue, StreamingPreflight $preflight): RedirectResponse
     {
         $livestream = UserLivestream::where('user_id', $request->user()->id)->findOrFail($id);
 
@@ -839,6 +840,11 @@ class SupporterLivestreamController extends Controller
             return redirect()->back()->withErrors([
                 'go_live' => 'Cannot queue the cloud stream in this state (status: '.$livestream->status.'). End any active stream or open a new meeting.',
             ]);
+        }
+
+        $gate = $preflight->check($livestream, $request->user());
+        if (! $gate->allowed) {
+            return redirect()->back()->withErrors(['go_live' => $gate->reason]);
         }
 
         $streamKey = $livestream->getDecryptedStreamKey();

--- a/app/Services/Streaming/PreflightResult.php
+++ b/app/Services/Streaming/PreflightResult.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Streaming;
+
+final class PreflightResult
+{
+    public function __construct(
+        public readonly bool $allowed,
+        public readonly ?string $reason = null,
+        public readonly ?string $code = null,
+    ) {}
+
+    public static function allow(): self
+    {
+        return new self(true);
+    }
+
+    public static function deny(string $reason, string $code): self
+    {
+        return new self(false, $reason, $code);
+    }
+}

--- a/app/Services/Streaming/StreamingPreflight.php
+++ b/app/Services/Streaming/StreamingPreflight.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Services\Streaming;
+
+use App\Models\OrganizationLivestream;
+use App\Models\StreamingMonthlyUsage;
+use App\Models\User;
+use App\Models\UserLivestream;
+use Carbon\Carbon;
+
+/**
+ * Spec gates 3, 4, 7 (INTEGRATION.pdf):
+ *   3. organization subscription is active
+ *   4. user permission to stream
+ *   7. streaming hours / billing precheck
+ *
+ * Step 6 (recording-consent acceptance) is intentionally not enforced here:
+ * the existing `livestream_recording_declines` records are written by *guests*
+ * after they join, so a queue-time check would always pass. Consent gating
+ * belongs in the join flow / recording trigger, not at SQS enqueue.
+ *
+ * Every gate is opt-in via config('streaming.gates.*') and disabled by default.
+ */
+final class StreamingPreflight
+{
+    public function check(
+        UserLivestream|OrganizationLivestream $livestream,
+        User $user,
+    ): PreflightResult {
+        if ($result = $this->checkSubscription($user)) {
+            return $result;
+        }
+
+        if ($result = $this->checkPermission($user)) {
+            return $result;
+        }
+
+        if ($result = $this->checkMonthlyQuota($livestream)) {
+            return $result;
+        }
+
+        return PreflightResult::allow();
+    }
+
+    private function checkSubscription(User $user): ?PreflightResult
+    {
+        if (! (bool) config('streaming.gates.require_subscription', false)) {
+            return null;
+        }
+
+        // Cashier's `subscribed()` falls back to the "default" subscription type
+        // when none is given. Let env override the type if the project uses
+        // multiple subscription products.
+        $type = (string) config('streaming.gates.subscription_type', 'default');
+        if (! $user->subscribed($type)) {
+            return PreflightResult::deny(
+                'Active subscription is required to start a cloud stream.',
+                'subscription_inactive',
+            );
+        }
+
+        return null;
+    }
+
+    private function checkPermission(User $user): ?PreflightResult
+    {
+        $permission = (string) config('streaming.gates.permission_name', '');
+        if ($permission === '') {
+            return null;
+        }
+
+        if (! $user->can($permission)) {
+            return PreflightResult::deny(
+                "You do not have permission to start a cloud stream ({$permission}).",
+                'permission_denied',
+            );
+        }
+
+        return null;
+    }
+
+    private function checkMonthlyQuota(
+        UserLivestream|OrganizationLivestream $livestream,
+    ): ?PreflightResult {
+        $hardCap = (int) config('streaming.gates.hard_quota_minutes', 0);
+        if ($hardCap <= 0) {
+            return null;
+        }
+
+        $orgId = $this->organizationKey($livestream);
+        $usage = StreamingMonthlyUsage::query()
+            ->where('organization_id', $orgId)
+            ->where('month_key', Carbon::now()->format('Y-m'))
+            ->first();
+
+        $used = (int) ($usage?->total_minutes ?? 0);
+        if ($used >= $hardCap) {
+            return PreflightResult::deny(
+                "Monthly streaming quota exhausted ({$used}/{$hardCap} minutes).",
+                'quota_exhausted',
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Mirror StreamingQueueService::accountUsageIfNeeded — usage rows key off
+     * organization_id for org streams and user id for supporter streams.
+     */
+    private function organizationKey(UserLivestream|OrganizationLivestream $livestream): int
+    {
+        return $livestream instanceof OrganizationLivestream
+            ? (int) $livestream->organization_id
+            : (int) $livestream->user_id;
+    }
+}

--- a/config/streaming.php
+++ b/config/streaming.php
@@ -46,6 +46,25 @@ return [
     ],
 
     /*
+     * Pre-launch gates for queueStreamRelayJob (INTEGRATION.pdf steps 3, 4, 7).
+     * Every gate defaults to off so existing flows are unchanged.
+     *
+     *   STREAMING_REQUIRE_SUBSCRIPTION=true       — blocks if Cashier subscription is inactive
+     *   STREAMING_SUBSCRIPTION_TYPE=default       — Cashier subscription name to check
+     *   STREAMING_PERMISSION_NAME=livestream.start — Spatie/Gate ability checked on the host user
+     *   STREAMING_HARD_QUOTA_MINUTES=3000          — blocks once a calendar-month total hits this cap
+     */
+    'gates' => [
+        'require_subscription' => filter_var(
+            env('STREAMING_REQUIRE_SUBSCRIPTION', false),
+            FILTER_VALIDATE_BOOLEAN
+        ),
+        'subscription_type' => env('STREAMING_SUBSCRIPTION_TYPE', 'default'),
+        'permission_name' => env('STREAMING_PERMISSION_NAME', ''),
+        'hard_quota_minutes' => (int) env('STREAMING_HARD_QUOTA_MINUTES', 0),
+    ],
+
+    /*
      * Without a real ECS/Lambda/etc. worker that polls SQS and POSTs /api/streaming/status,
      * meetings stay queued forever and never show "live".
      *

--- a/tests/Unit/Services/Streaming/StreamingPreflightTest.php
+++ b/tests/Unit/Services/Streaming/StreamingPreflightTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit\Services\Streaming;
+
+use App\Models\OrganizationLivestream;
+use App\Models\User;
+use App\Services\Streaming\StreamingPreflight;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Quota gate (config 'streaming.gates.hard_quota_minutes') is intentionally
+ * not covered here — it reads StreamingMonthlyUsage from the database, and
+ * the project's migration set is MySQL-only so the default in-memory SQLite
+ * test connection fails to migrate. Cover that gate with an integration test
+ * that runs against the project's real MySQL once test-DB tooling is in place.
+ */
+class StreamingPreflightTest extends TestCase
+{
+    private StreamingPreflight $preflight;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->preflight = new StreamingPreflight();
+        config()->set('streaming.gates.require_subscription', false);
+        config()->set('streaming.gates.permission_name', '');
+        config()->set('streaming.gates.hard_quota_minutes', 0);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_allows_by_default_when_no_gates_are_enabled(): void
+    {
+        $user = $this->makeUserMock();
+        $livestream = $this->makeOrgLivestream(['organization_id' => 99]);
+
+        $result = $this->preflight->check($livestream, $user);
+
+        $this->assertTrue($result->allowed);
+    }
+
+    public function test_blocks_when_subscription_is_required_but_user_is_not_subscribed(): void
+    {
+        config()->set('streaming.gates.require_subscription', true);
+
+        $user = $this->makeUserMock(subscribed: false);
+        $livestream = $this->makeOrgLivestream(['organization_id' => 1]);
+
+        $result = $this->preflight->check($livestream, $user);
+
+        $this->assertFalse($result->allowed);
+        $this->assertSame('subscription_inactive', $result->code);
+    }
+
+    public function test_allows_when_subscription_is_required_and_user_is_subscribed(): void
+    {
+        config()->set('streaming.gates.require_subscription', true);
+
+        $user = $this->makeUserMock(subscribed: true);
+        $livestream = $this->makeOrgLivestream(['organization_id' => 1]);
+
+        $result = $this->preflight->check($livestream, $user);
+
+        $this->assertTrue($result->allowed);
+    }
+
+    public function test_blocks_when_permission_is_required_and_user_lacks_it(): void
+    {
+        config()->set('streaming.gates.permission_name', 'livestream.start');
+
+        $user = $this->makeUserMock(can: false);
+        $livestream = $this->makeOrgLivestream(['organization_id' => 1]);
+
+        $result = $this->preflight->check($livestream, $user);
+
+        $this->assertFalse($result->allowed);
+        $this->assertSame('permission_denied', $result->code);
+    }
+
+    public function test_allows_when_permission_is_required_and_user_has_it(): void
+    {
+        config()->set('streaming.gates.permission_name', 'livestream.start');
+
+        $user = $this->makeUserMock(can: true);
+        $livestream = $this->makeOrgLivestream(['organization_id' => 1]);
+
+        $result = $this->preflight->check($livestream, $user);
+
+        $this->assertTrue($result->allowed);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function makeOrgLivestream(array $attributes = []): OrganizationLivestream
+    {
+        $livestream = new OrganizationLivestream();
+        $livestream->forceFill(array_merge(['id' => 1], $attributes));
+
+        return $livestream;
+    }
+
+    private function makeUserMock(bool $subscribed = false, bool $can = true): User
+    {
+        /** @var User&\Mockery\MockInterface $user */
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->shouldReceive('subscribed')->andReturn($subscribed);
+        $user->shouldReceive('can')->andReturn($can);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `App\Services\Streaming\StreamingPreflight` codifying INTEGRATION.pdf spec gates 3 (subscription), 4 (user permission), and 7 (monthly hours quota) as one service with feature flags.
- Wires it into `queueStreamRelayJob` in both Organization and Supporter livestream controllers.
- Every gate is off by default — opt in per-environment via `STREAMING_REQUIRE_SUBSCRIPTION`, `STREAMING_PERMISSION_NAME`, `STREAMING_HARD_QUOTA_MINUTES`.
- 5 unit tests, all green (`vendor/bin/pest --filter=StreamingPreflightTest`).

Spec gate 6 (recording-consent acceptance) is intentionally not enforced here — `livestream_recording_declines` is written by guests *after* they join, so a queue-time check would always pass. That belongs in the join / recording-trigger flow, not at SQS enqueue. Documented in the service's class doc.

Quota gate isn't unit-tested here because the project's migrations use MySQL-only DDL (`ALTER TABLE ... MODIFY COLUMN ENUM(...)`) and the default test connection is in-memory SQLite. Documented in the test class — should be covered by an integration test once test-DB tooling is in place.

## Test plan

- [x] `php8.2 vendor/bin/pest --filter=StreamingPreflightTest` → 5/5 passed
- [x] Both controllers parse cleanly under PHP 8.2
- [ ] Manual smoke: enable `STREAMING_HARD_QUOTA_MINUTES=1`, seed a `streaming_monthly_usages` row past the cap, hit the queue endpoint, expect `quota_exhausted` redirect
- [ ] Manual smoke: enable `STREAMING_REQUIRE_SUBSCRIPTION=true` for an unsubscribed user, expect `subscription_inactive` redirect
- [ ] Code review by Riyad before merge — this touches Laravel post-SQS code

🤖 Generated with [Claude Code](https://claude.com/claude-code)